### PR TITLE
feature 174 (mockFetch): add support for aborting request

### DIFF
--- a/packages/mock-addon/package.json
+++ b/packages/mock-addon/package.json
@@ -40,6 +40,7 @@
     "lint": "eslint .",
     "lint:fix": "yarn run lint --fix",
     "test": "jest src",
+    "test:debug": "node --nolazy --inspect-brk ../../node_modules/.bin/jest --runInBand --colors --verbose",
     "prerelease": "zx scripts/prepublish-checks.mjs",
     "release": "yarn build && auto shipit"
   },

--- a/packages/mock-addon/src/utils/faker.test.js
+++ b/packages/mock-addon/src/utils/faker.test.js
@@ -135,6 +135,9 @@ describe('Faker', () => {
 
             faker.makeInitialRequestMap(requests);
 
+            /**
+             * @jest-environment jsdom
+             */
             it('should abort request if abort is called', (done) => {
                 const abortController = new AbortController();
 

--- a/packages/mock-addon/src/utils/request.js
+++ b/packages/mock-addon/src/utils/request.js
@@ -5,10 +5,12 @@ export function Request(input, options = {}) {
         this.method = options.method || input.method || 'GET';
         this.url = input.url;
         this.body = options.body || input.body || null;
+        this.signal = options.signal || input.signal || null;
     } else {
         this.method = options.method || 'GET';
         this.url = input;
         this.body = options.body || null;
+        this.signal = options.signal || null;
     }
 
     const _url = getBaseUrl(this.url);

--- a/packages/mock-addon/src/utils/request.test.js
+++ b/packages/mock-addon/src/utils/request.test.js
@@ -1,0 +1,28 @@
+import { Request } from './request';
+
+const mockURL = 'http://storybook-addon-mock.com';
+
+describe('Request', () => {
+    it('should support an abort signal', () => {
+        const controller = new AbortController();
+        const request = new Request(mockURL, { signal: controller.signal });
+
+        controller.abort();
+
+        expect(request.signal.aborted).toBe(true);
+    });
+
+    it('should support an abort signal listener', (done) => {
+        const controller = new AbortController();
+        const request = new Request(mockURL, { signal: controller.signal });
+
+        request.signal.addEventListener('abort', () => {
+            expect(request.signal.aborted).toBe(true);
+            done();
+        });
+
+        expect(request.signal.aborted).toBe(false);
+
+        controller.abort();
+    });
+});


### PR DESCRIPTION
Adds support for the AbortController.signal so that abort mechanisms in application/component code are respected inside storybook when calling mocked resources.

Fixes #174 