### PR TITLE
feature 174 (mockFetch): add support for aborting requests

### DIFF
--- a/packages/mock-addon/src/utils/faker.js
+++ b/packages/mock-addon/src/utils/faker.js
@@ -144,7 +144,11 @@ export class Faker {
 
                 timeoutId && clearTimeout(timeoutId);
 
-                reject(new DOMException(request.signal.reason, 'AbortError'));
+                const error = new Error(request.signal.reason);
+
+                error.name = 'AbortError';
+
+                reject(error);
             });
         });
     };

--- a/packages/mock-addon/src/utils/request.js
+++ b/packages/mock-addon/src/utils/request.js
@@ -5,10 +5,12 @@ export function Request(input, options = {}) {
         this.method = options.method || input.method || 'GET';
         this.url = input.url;
         this.body = options.body || input.body || null;
+        this.signal = options.signal || input.signal || null;
     } else {
         this.method = options.method || 'GET';
         this.url = input;
         this.body = options.body || null;
+        this.signal = options.signal || null;
     }
 
     const _url = getBaseUrl(this.url);

--- a/packages/mock-addon/src/utils/request.test.js
+++ b/packages/mock-addon/src/utils/request.test.js
@@ -1,0 +1,28 @@
+import { Request } from './request';
+
+const mockURL = 'http://storybook-addon-mock.com';
+
+describe('Request', () => {
+    it('should support an abort signal', () => {
+        const controller = new AbortController();
+        const request = new Request(mockURL, { signal: controller.signal });
+
+        controller.abort();
+
+        expect(request.signal.aborted).toBe(true);
+    });
+
+    it('should support an abort signal listener', (done) => {
+        const controller = new AbortController();
+        const request = new Request(mockURL, { signal: controller.signal });
+
+        request.signal.addEventListener('abort', () => {
+            expect(request.signal.aborted).toBe(true);
+            done();
+        });
+
+        expect(request.signal.aborted).toBe(false);
+
+        controller.abort();
+    });
+});


### PR DESCRIPTION
Apologies for the mess when creating this review.

I have tried to stay as close to native implementation as I am aware of. I was unable to throw a DOMException because the CI tests are probably running in a node environment.

Fixes #174 