### PR TITLE
fix: add missing properties and methods to response headers

### DIFF
--- a/packages/mock-addon/src/utils/response.js
+++ b/packages/mock-addon/src/utils/response.js
@@ -4,9 +4,9 @@ import { defaultResponseHeaders } from './headers';
 export function Response(url, status, responseText) {
     const keys = [];
     const all = [];
-    const headers = {
+    this.headers = new Headers({
         ...defaultResponseHeaders,
-    };
+    });
     // eslint-disable-next-line no-bitwise
     this.ok = ((status / 100) | 0) === 2; // 200-299
     this.statusText = statusTextMap[status.toString()];
@@ -20,11 +20,11 @@ export function Response(url, status, responseText) {
                 : JSON.stringify(responseText)
         );
     this.json = () => Promise.resolve(responseText);
-    (this.clone = () => new Response(url, status, responseText)),
-        (this.headers = {
-            keys: () => keys,
-            entries: () => all,
-            get: (n) => headers[n.toLowerCase()],
-            has: (n) => n.toLowerCase() in headers,
-        });
+    (this.clone = () => new Response(url, status, responseText))
+        // (this.headers = {
+        //     keys: () => keys,
+        //     entries: () => all,
+        //     get: (n) => headers[n.toLowerCase()],
+        //     has: (n) => n.toLowerCase() in headers,
+        // });
 }

--- a/packages/mock-addon/src/utils/response.js
+++ b/packages/mock-addon/src/utils/response.js
@@ -18,5 +18,5 @@ export function Response(url, status, responseText) {
                 : JSON.stringify(responseText)
         );
     this.json = () => Promise.resolve(responseText);
-    (this.clone = () => new Response(url, status, responseText))
+    this.clone = () => new Response(url, status, responseText);
 }

--- a/packages/mock-addon/src/utils/response.js
+++ b/packages/mock-addon/src/utils/response.js
@@ -2,8 +2,6 @@ import statusTextMap from './statusMap';
 import { defaultResponseHeaders } from './headers';
 
 export function Response(url, status, responseText) {
-    const keys = [];
-    const all = [];
     this.headers = new Headers({
         ...defaultResponseHeaders,
     });
@@ -21,10 +19,4 @@ export function Response(url, status, responseText) {
         );
     this.json = () => Promise.resolve(responseText);
     (this.clone = () => new Response(url, status, responseText))
-        // (this.headers = {
-        //     keys: () => keys,
-        //     entries: () => all,
-        //     get: (n) => headers[n.toLowerCase()],
-        //     has: (n) => n.toLowerCase() in headers,
-        // });
 }

--- a/packages/mock-addon/src/utils/response.test.js
+++ b/packages/mock-addon/src/utils/response.test.js
@@ -33,6 +33,7 @@ describe('Response', () => {
     it('should return a response with headers that contain required properties and methods', async () => {
         const response = new Response(mockURL, 200, {});
         const headers = response.headers;
+        expect(headers).toBeDefined();
         const hasAll = Object.keys(Headers).every((key) => headers[key] !== undefined);
         expect(hasAll).toBe(true);
     });

--- a/packages/mock-addon/src/utils/response.test.js
+++ b/packages/mock-addon/src/utils/response.test.js
@@ -34,7 +34,9 @@ describe('Response', () => {
         const response = new Response(mockURL, 200, {});
         const headers = response.headers;
         expect(headers).toBeDefined();
-        const hasAll = Object.keys(Headers).every((key) => headers[key] !== undefined);
+        const hasAll = Object.keys(Headers).every(
+            (key) => headers[key] !== undefined
+        );
         expect(hasAll).toBe(true);
     });
 });

--- a/packages/mock-addon/src/utils/response.test.js
+++ b/packages/mock-addon/src/utils/response.test.js
@@ -30,4 +30,10 @@ describe('Response', () => {
         // eslint-disable-next-line prettier/prettier
         expect(actual).toEqual("{\"key\":\"test\"}");
     });
+    it('should return a response with headers that contain required properties and methods', async () => {
+        const response = new Response(mockURL, 200, {});
+        const headers = response.headers;
+        const hasAll = Object.keys(Headers).every((key) => headers[key] !== undefined);
+        expect(hasAll).toBe(true);
+    });
 });


### PR DESCRIPTION
The response headers lack some of the properties and methods present in the original [`Headers` class](https://developer.mozilla.org/en-US/docs/Web/API/Headers).

This PR utilizes the `Headers` constructor to create the headers object instead of setting each individually.

This fixes #186 