### PR TITLE
Add response headers option support + add HEAD HTTM request method mocking support

### DIFF
--- a/packages/mock-addon/src/utils/faker.js
+++ b/packages/mock-addon/src/utils/faker.js
@@ -134,16 +134,16 @@ export class Faker {
             return global.realFetch(input, options);
         }
 
-        const { response, status, delay = 0 } = matched;
+        const { response, status, delay = 0, headers = {} } = matched;
 
         let mockResponseSent = false;
 
         return new Promise((resolve, reject) => {
             const timeoutId = setTimeout(() => {
                 if (typeof response === 'function') {
-                    resolve(CustomResponse(url, status, response(request)));
+                    resolve(CustomResponse(url, status, response(request), headers));
                 } else {
-                    resolve(CustomResponse(url, status, response));
+                    resolve(CustomResponse(url, status, response, headers));
                 }
 
                 mockResponseSent = true;

--- a/packages/mock-addon/src/utils/faker.js
+++ b/packages/mock-addon/src/utils/faker.js
@@ -134,16 +134,25 @@ export class Faker {
             return global.realFetch(input, options);
         }
 
-        const { response, status, delay = 0, headers = {} } = matched;
+        const { response, status, delay = 0, responseHeaders = {} } = matched;
 
         let mockResponseSent = false;
 
         return new Promise((resolve, reject) => {
             const timeoutId = setTimeout(() => {
                 if (typeof response === 'function') {
-                    resolve(CustomResponse(url, status, response(request), headers));
+                    resolve(
+                        CustomResponse(
+                            url,
+                            status,
+                            response(request),
+                            responseHeaders
+                        )
+                    );
                 } else {
-                    resolve(CustomResponse(url, status, response, headers));
+                    resolve(
+                        CustomResponse(url, status, response, responseHeaders)
+                    );
                 }
 
                 mockResponseSent = true;

--- a/packages/mock-addon/src/utils/response.js
+++ b/packages/mock-addon/src/utils/response.js
@@ -14,8 +14,8 @@ export function CustomResponse(url, status, responseText, headers) {
         statusText: statusTextMap[status.toString()],
         headers: new Headers({
             ...defaultResponseHeaders,
-            ...headers
+            ...headers,
         }),
-        url
+        url,
     });
 }

--- a/packages/mock-addon/src/utils/response.js
+++ b/packages/mock-addon/src/utils/response.js
@@ -2,7 +2,7 @@ import 'whatwg-fetch';
 import statusTextMap from './statusMap';
 import { defaultResponseHeaders } from './headers';
 
-export function CustomResponse(url, status, responseText) {
+export function CustomResponse(url, status, responseText, headers) {
     const text =
         typeof responseText === 'string'
             ? responseText
@@ -14,7 +14,8 @@ export function CustomResponse(url, status, responseText) {
         statusText: statusTextMap[status.toString()],
         headers: new Headers({
             ...defaultResponseHeaders,
+            ...headers
         }),
-        url,
+        url
     });
 }

--- a/packages/mock-addon/src/utils/validator.js
+++ b/packages/mock-addon/src/utils/validator.js
@@ -1,6 +1,6 @@
 import statusTextMap from '../utils/statusMap';
 
-const methods = ['GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS'];
+const methods = ['GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD'];
 const statusCodes = Object.keys(statusTextMap);
 
 const isObject = (value) =>


### PR DESCRIPTION
Some informations I need to mock are only existing in the response headers.
I thus implemented a simple way to support that in this addon.

Here is how it should work:
```js
...
mockData: [
  {
    url: "/my-url",
    method: 'HEAD',
    status: 200,
    responseHeaders: {
      'X-Cache-Status': 'HIT'
    },
    response: {}
  }
]
...
```