### PR TITLE
Allow any defined response value

### DIFF
--- a/packages/mock-addon-docs/stories/docs/installation-setup.mdx
+++ b/packages/mock-addon-docs/stories/docs/installation-setup.mdx
@@ -1,4 +1,3 @@
-
 import { Meta } from '@storybook/addon-docs';
 import LinkTo from '@storybook/addon-links/react';
 import { Footer } from './footer';
@@ -22,6 +21,7 @@ import { Footer } from './footer';
 ```sh
     npm i storybook-addon-mock -D
 ```
+
 <div> Using yarn </div>
 
 ```sh
@@ -75,19 +75,17 @@ export default {
 const Template = () => <FetchExample />;
 
 export const FetchCall = Template.bind({});
-
 ```
 
 Each mock object contains the following properties.
 
-| Property   | Description                                                                                 | Required | Default |
-| ---------- | :------------------------------------------------------------------------------------------ | :------- | :------ |
-| `url`      | Supports both **named parameters** (`/:foo/:bar`) and **query parameters**.(`/foo?bar=true`) | true        |    -    |
-| `method`   | Supports `GET`, `POST`, `PUT`, `PATCH` and `DELETE` methods.                                                   |    true    | - |
-| `status`   | All possible [HTTP status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).                                                              |     true   |  -  |
-| `response` | A valid JSON format(Array, Object, or null) or function. <br/> Response function is a function that contains request object as a parameter. See the **Custom Response** section for example.  | true        |    -    |
-| `delay`    | Emulate delayed response time in milliseconds.                                              |     -    | `0`     |
-
+| Property   | Description                                                                                                                                                                     | Required | Default |
+| ---------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------- | :------ |
+| `url`      | Supports both **named parameters** (`/:foo/:bar`) and **query parameters**.(`/foo?bar=true`)                                                                                    | true     | -       |
+| `method`   | Supports `GET`, `POST`, `PUT`, `PATCH` and `DELETE` methods.                                                                                                                    | true     | -       |
+| `status`   | All possible [HTTP status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).                                                                                     | true     | -       |
+| `response` | A value or a function that returns a value. <br/> Response function is a function that contains request object as a parameter. See the **Custom Response** section for example. | true     | -       |
+| `delay`    | Emulate delayed response time in milliseconds.                                                                                                                                  | -        | `0`     |
 
 <br />
 

--- a/packages/mock-addon-docs/stories/docs/installation-setup.mdx
+++ b/packages/mock-addon-docs/stories/docs/installation-setup.mdx
@@ -85,7 +85,7 @@ Each mock object contains the following properties.
 | `url`      | Supports both **named parameters** (`/:foo/:bar`) and **query parameters**.(`/foo?bar=true`) | true        |    -    |
 | `method`   | Supports `GET`, `POST`, `PUT`, `PATCH` and `DELETE` methods.                                                   |    true    | - |
 | `status`   | All possible [HTTP status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).                                                              |     true   |  -  |
-| `response` | A valid JSON format(Array or Object) or function. <br/> Response function is a function that contains request object as a parameter. See the **Custom Response** section for example.  | true        |    -    |
+| `response` | A valid JSON format(Array, Object, or null) or function. <br/> Response function is a function that contains request object as a parameter. See the **Custom Response** section for example.  | true        |    -    |
 | `delay`    | Emulate delayed response time in milliseconds.                                              |     -    | `0`     |
 
 

--- a/packages/mock-addon/src/utils/validator.js
+++ b/packages/mock-addon/src/utils/validator.js
@@ -22,12 +22,7 @@ export const schema = {
         return value && statusCodes.indexOf(value.toString()) >= 0;
     },
     response: (value) => {
-        return (
-            isObject(value) ||
-            Array.isArray(value) ||
-            typeof value === 'function' ||
-            value === null
-        );
+        return typeof value !== 'undefined';
     },
     delay: (value) => {
         return value ? typeof value === 'number' : true;

--- a/packages/mock-addon/src/utils/validator.js
+++ b/packages/mock-addon/src/utils/validator.js
@@ -23,10 +23,10 @@ export const schema = {
     },
     response: (value) => {
         return (
-            (isObject(value) ||
-                Array.isArray(value) ||
-                typeof value === 'function') &&
-            value !== null
+            isObject(value) ||
+            Array.isArray(value) ||
+            typeof value === 'function' ||
+            value === null
         );
     },
     delay: (value) => {

--- a/packages/mock-addon/src/utils/validator.test.js
+++ b/packages/mock-addon/src/utils/validator.test.js
@@ -204,6 +204,18 @@ describe('Validator', () => {
             expect(actual).toEqual([]);
         });
 
+        it('should return empty error if response is null', () => {
+            const mock = {
+                url: 'https://jsonplaceholder.typicode.com/todos/:id',
+                method: 'GET',
+                status: 200,
+                delay: 0,
+                response: null,
+            };
+            const actual = validate(mock, schema);
+            expect(actual).toEqual([]);
+        });
+
         it('should return not valid response error if response is a string', () => {
             const mock = {
                 url: 'https://jsonplaceholder.typicode.com/todos/:id',
@@ -214,18 +226,6 @@ describe('Validator', () => {
             };
             const actual = validate(mock, schema);
             expect(actual).toEqual(['response: "string" is not valid.']);
-        });
-
-        it('should return not valid response error if response is null', () => {
-            const mock = {
-                url: 'https://jsonplaceholder.typicode.com/todos/:id',
-                method: 'GET',
-                status: 200,
-                delay: 0,
-                response: null,
-            };
-            const actual = validate(mock, schema);
-            expect(actual).toEqual(['response: null is not valid.']);
         });
     });
     describe('validate delay', () => {

--- a/packages/mock-addon/src/utils/validator.test.js
+++ b/packages/mock-addon/src/utils/validator.test.js
@@ -204,6 +204,18 @@ describe('Validator', () => {
             expect(actual).toEqual([]);
         });
 
+        it('should return not valid response error if response is a string', () => {
+            const mock = {
+                url: 'https://jsonplaceholder.typicode.com/todos/:id',
+                method: 'GET',
+                status: 200,
+                delay: 0,
+                response: 'string',
+            };
+            const actual = validate(mock, schema);
+            expect(actual).toEqual([]);
+        });
+
         it('should return empty error if response is null', () => {
             const mock = {
                 url: 'https://jsonplaceholder.typicode.com/todos/:id',
@@ -216,16 +228,16 @@ describe('Validator', () => {
             expect(actual).toEqual([]);
         });
 
-        it('should return not valid response error if response is a string', () => {
+        it('should return not valid response error if response is undefined', () => {
             const mock = {
                 url: 'https://jsonplaceholder.typicode.com/todos/:id',
                 method: 'GET',
                 status: 200,
                 delay: 0,
-                response: 'string',
+                response: undefined,
             };
             const actual = validate(mock, schema);
-            expect(actual).toEqual(['response: "string" is not valid.']);
+            expect(actual).toEqual(['response: undefined is not valid.']);
         });
     });
     describe('validate delay', () => {

--- a/packages/mock-addon/src/utils/validator.test.js
+++ b/packages/mock-addon/src/utils/validator.test.js
@@ -204,7 +204,7 @@ describe('Validator', () => {
             expect(actual).toEqual([]);
         });
 
-        it('should return not valid response error if response is a string', () => {
+        it('should return empty error if response is a string', () => {
             const mock = {
                 url: 'https://jsonplaceholder.typicode.com/todos/:id',
                 method: 'GET',


### PR DESCRIPTION
The response validator as written fails for valid JSON (e.g. `null`, `"foo"`, `true`, etc.). If the validator is going to enforce valid JSON, it should allow all JSON values, not just some. Furthermore, in my opinion this package shouldn't be concerned with validating a user-provided response, perhaps other than asserting that it is defined. Some APIs return invalid JSON - this package should support mocking those, too.

My changes here relax the `response` validation to merely asserting that it is not `undefined`. One could argue that `undefined` should be allowed too, but in this PR I'm only interested in permitting any defined value. 

This PR would supersede https://github.com/linearlabs-workspace/storybook-addon-mock/pull/201 and close https://github.com/linearlabs-workspace/storybook-addon-mock/issues/200